### PR TITLE
Fix: Failed to download videos after upgrade

### DIFF
--- a/SettingsTemplate.yaml
+++ b/SettingsTemplate.yaml
@@ -27,6 +27,7 @@ body:
               - mkv
               - avi
               - flv
+              - mov
               - webm
     - type: dropdown
       attributes:
@@ -39,4 +40,6 @@ body:
               - m4a
               - wav
               - flac
+              - aac
+              - opus
             

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -28,7 +28,7 @@ from results import (
     empty_result,
     query_result,
     download_ffmpeg_result,
-    ffmpeg_not_found_result
+    ffmpeg_not_found_result,
 )
 from ytdlp import CustomYoutubeDL
 
@@ -75,6 +75,8 @@ def query(query: str) -> ResultResponse:
 
     if verify_ffmpeg():
         return send_results([download_ffmpeg_result(PLUGIN_ROOT)])
+
+    extract_ffmpeg()
 
     if not query.strip():
         return send_results([init_results(d_path)])

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -167,7 +167,7 @@ def download(
     format = (
         f"-f b -x --audio-format {pref_audio_path} --audio-quality 0"
         if is_audio
-        else f"-f {format_id}+ba --remux-video {pref_video_path}"
+        else f"-f {format_id}+ba[ext=mp3]/{format_id}+ba[ext=aac]/{format_id}+ba[ext=m4a]/{format_id}+ba[ext=wav]/{format_id}+ba --remux-video {pref_video_path}"
     )
 
     update = (

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -4,15 +4,23 @@
 # Date: 2024-07-28
 
 import os
-import re
 import subprocess
-import zipfile
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Tuple
 
 from pyflowlauncher import Plugin, ResultResponse, send_results
 from pyflowlauncher.settings import settings
+from utils import (
+    is_valid_url,
+    sort_by_resolution,
+    sort_by_tbr,
+    sort_by_fps,
+    sort_by_size,
+    verify_ffmpeg_binaries,
+    verify_ffmpeg,
+    extract_ffmpeg,
+)
 from results import (
     init_results,
     invalid_result,
@@ -20,6 +28,7 @@ from results import (
     empty_result,
     query_result,
     download_ffmpeg_result,
+    ffmpeg_not_found_result
 )
 from ytdlp import CustomYoutubeDL
 
@@ -27,49 +36,9 @@ PLUGIN_ROOT = os.path.dirname(__file__)
 EXE_PATH = os.path.join(PLUGIN_ROOT, "yt-dlp.exe")
 CHECK_INTERVAL_DAYS = 5
 DEFAULT_DOWNLOAD_PATH = str(Path.home() / "Downloads")
-URL_REGEX = (
-    "((http|https)://)(www.)?"
-    + "[a-zA-Z0-9@:%._\\+~#?&//=]"
-    + "{1,256}\\.[a-z]"
-    + "{2,6}\\b([-a-zA-Z0-9@:%"
-    + "._\\+~#?&//=]*)"
-)
+
 
 plugin = Plugin()
-
-
-def is_valid_url(url: str) -> bool:
-    """
-    Check if the given URL is valid based on a predefined regex pattern.
-
-    Args:
-        url (str): The URL string to validate.
-
-    Returns:
-        bool: True if the URL matches the regex pattern, False otherwise.
-    """
-
-    return bool(re.match(URL_REGEX, url))
-
-
-def verify_ffmpeg_binaries():
-    ffmpeg_zip = os.path.join(PLUGIN_ROOT, "ffmpeg.zip")
-    ffmpeg_path = os.path.join(PLUGIN_ROOT, "ffmpeg.exe")
-    ffprobe_path = os.path.join(PLUGIN_ROOT, "ffprobe.exe")
-    
-    return (not os.path.exists(ffmpeg_path) or not os.path.exists(ffprobe_path)) and not os.path.exists(ffmpeg_zip)
-
-
-def extract_ffmpeg():
-    ffmpeg_zip = os.path.join(PLUGIN_ROOT, "ffmpeg.zip")
-    
-    if os.path.exists(ffmpeg_zip):
-        try:
-            with zipfile.ZipFile(ffmpeg_zip, "r") as zip_ref:
-                zip_ref.extractall(os.path.dirname(__file__))
-            os.remove(ffmpeg_zip)
-        except Exception as _:
-            pass
 
 
 def fetch_settings() -> Tuple[str, str, str, str]:
@@ -100,75 +69,11 @@ def fetch_settings() -> Tuple[str, str, str, str]:
     return download_path, sorting_order, pref_video_format, pref_audio_format
 
 
-def sort_by_resolution(formats):
-    """
-    Sorts a list of video formats by their resolution in descending order.
-
-    Returns:
-        list of dict: The list of video formats sorted by resolution in descending order.
-                      Audio-only formats are considered to have the lowest resolution.
-    """
-
-    def resolution_to_tuple(resolution):
-        if resolution == "audio only":
-            return (0, 0)
-        return tuple(map(int, resolution.split("x")))
-
-    return sorted(
-        formats, key=lambda x: resolution_to_tuple(x["resolution"]), reverse=True
-    )
-
-
-def sort_by_tbr(formats):
-    """
-    Sort a list of video formats by their 'tbr' (total bitrate) in descending order.
-
-    Returns:
-        list: The input list sorted by the 'tbr' value in descending order.
-    """
-    return sorted(formats, key=lambda x: x["tbr"], reverse=True)
-
-
-def sort_by_fps(formats):
-    """
-    Sort a list of video formats by frames per second (fps) in descending order.
-
-    Returns:
-        list of dict: The list of video formats sorted by fps in descending order.
-                      Formats with None fps values are placed at the end.
-    """
-    return sorted(
-        formats,
-        key=lambda x: (
-            x["fps"] is None,
-            -x["fps"] if x["fps"] is not None else float("-inf"),
-        ),
-    )
-
-
-def sort_by_size(formats):
-    """
-    Sort a list of video formats by their file size in descending order.
-
-    Returns:
-        list of dict: The list of video formats sorted by file size in
-                      descending order. Formats with no file size information
-                      (None) are placed at the end of the list.
-    """
-    return sorted(
-        formats,
-        key=lambda x: (
-            x["filesize"] is None,
-            -x["filesize"] if x["filesize"] is not None else float("-inf"),
-        ),
-    )
-
-
 @plugin.on_method
 def query(query: str) -> ResultResponse:
     d_path, sort, pvf, paf = fetch_settings()
-    
-    if verify_ffmpeg_binaries():
+
+    if verify_ffmpeg():
         return send_results([download_ffmpeg_result(PLUGIN_ROOT)])
 
     if not query.strip():
@@ -213,27 +118,34 @@ def query(query: str) -> ResultResponse:
     elif sort == "FPS":
         formats = sort_by_fps(formats)
 
-    results = [
-        query_result(
-            query,
-            str(info.get("thumbnail")),
-            str(info.get("title")),
-            format,
-            d_path,
-            pvf,
-            paf,
-        )
-        for format in formats
-    ]
+    results = []
+    if verify_ffmpeg_binaries():
+        results.extend([ffmpeg_not_found_result()])
+    results.extend(
+        [
+            query_result(
+                query,
+                str(info.get("thumbnail")),
+                str(info.get("title")),
+                format,
+                d_path,
+                pvf,
+                paf,
+            )
+            for format in formats
+        ]
+    )
     return send_results(results)
 
 
 @plugin.on_method
 def download_ffmpeg_binaries(PLUGIN_ROOT) -> None:
-    BIN_URL = "https://github.com/z1nc0r3/ffmpeg-binaries/blob/main/ffmpeg-bin.zip?raw=true"
+    BIN_URL = (
+        "https://github.com/z1nc0r3/ffmpeg-binaries/blob/main/ffmpeg-bin.zip?raw=true"
+    )
     FFMPEG_ZIP = os.path.join(PLUGIN_ROOT, "ffmpeg.zip")
     command = f'curl -L "{BIN_URL}" -o "{FFMPEG_ZIP}"'
-    
+
     subprocess.run(command)
 
 
@@ -251,7 +163,8 @@ def download(
     ffmpeg_path = os.path.dirname(__file__)
 
     format = (
-        f"-f b -x --audio-format {pref_audio_path} --audio-quality 0" if is_audio 
+        f"-f b -x --audio-format {pref_audio_path} --audio-quality 0"
+        if is_audio
         else f"-f {format_id}+ba --remux-video {pref_video_path}"
     )
 

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -5,6 +5,7 @@
 
 import os
 import re
+import subprocess
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Tuple
@@ -226,7 +227,27 @@ def download(
 
     command = f'yt-dlp "{url}" {format} -P {download_path} --windows-filenames --restrict-filenames --trim-filenames 50 --quiet --progress --no-mtime --force-overwrites --no-part {update}'
 
-    os.system(command)
+    exe_path = os.path.join(os.path.dirname(__file__), "yt-dlp.exe")
+    command = [
+        exe_path,
+        url,
+        *format.split(),
+        "-P",
+        download_path,
+        "--windows-filenames",
+        "--restrict-filenames",
+        "--trim-filenames",
+        "50",
+        "--quiet",
+        "--progress",
+        "--no-mtime",
+        "--force-overwrites",
+        "--no-part",
+        update,
+    ]
+
+    command = [arg for arg in command if arg]
+    subprocess.run(command)
 
 
 if __name__ == "__main__":

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -212,9 +212,10 @@ def download(
     is_audio: bool,
 ) -> None:
     last_modified_time = datetime.fromtimestamp(os.path.getmtime(EXE_PATH))
+    exe_path = os.path.join(os.path.dirname(__file__), "yt-dlp.exe")
 
     format = (
-        f"-f ba -x --audio-format {pref_audio_path}"
+        f"-f ba"
         if is_audio
         else f"-f {format_id}+ba --remux-video {pref_video_path}"
     )
@@ -225,9 +226,6 @@ def download(
         else ""
     )
 
-    command = f'yt-dlp "{url}" {format} -P {download_path} --windows-filenames --restrict-filenames --trim-filenames 50 --quiet --progress --no-mtime --force-overwrites --no-part {update}'
-
-    exe_path = os.path.join(os.path.dirname(__file__), "yt-dlp.exe")
     command = [
         exe_path,
         url,

--- a/plugin/results.py
+++ b/plugin/results.py
@@ -12,17 +12,33 @@ def init_results(download_path) -> Result:
 def invalid_result() -> Result:
     return Result(Title="Please check the URL for errors.", IcoPath="Images/error.png")
 
+def ffmpeg_not_found_result() -> Result:
+    return Result(
+        Title="FFmpeg is not installed!",
+        SubTitle="Some features may not work as expected.",
+        IcoPath="Images/error.png",
+    )
+
 
 def error_result() -> Result:
     return Result(
         Title="Something went wrong!",
-        SubTitle="Couldn't extract video information.",
+        SubTitle=f"Couldn't extract video information.",
         IcoPath="Images/error.png",
     )
 
 
 def empty_result() -> Result:
     return Result(Title="Couldn't find any video formats.", IcoPath="Images/error.png")
+
+
+def download_ffmpeg_result(dest_path) -> Result:
+    return Result(
+        Title="FFmpeg is not installed!",
+        SubTitle="Click this to download FFmpeg binaries.",
+        IcoPath="Images/error.png",
+        JsonRPCAction={"method": "download_ffmpeg_binaries", "parameters": [dest_path]},
+    )
 
 
 def query_result(

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -1,0 +1,118 @@
+import re
+import os
+import zipfile
+
+PLUGIN_ROOT = os.path.dirname(__file__)
+URL_REGEX = (
+    "((http|https)://)(www.)?"
+    + "[a-zA-Z0-9@:%._\\+~#?&//=]"
+    + "{1,256}\\.[a-z]"
+    + "{2,6}\\b([-a-zA-Z0-9@:%"
+    + "._\\+~#?&//=]*)"
+)
+
+
+def is_valid_url(url: str) -> bool:
+    """
+    Check if the given URL is valid based on a predefined regex pattern.
+
+    Args:
+        url (str): The URL string to validate.
+
+    Returns:
+        bool: True if the URL matches the regex pattern, False otherwise.
+    """
+
+    return bool(re.match(URL_REGEX, url))
+
+
+def sort_by_resolution(formats):
+    """
+    Sorts a list of video formats by their resolution in descending order.
+
+    Returns:
+        list of dict: The list of video formats sorted by resolution in descending order.
+                      Audio-only formats are considered to have the lowest resolution.
+    """
+
+    def resolution_to_tuple(resolution):
+        if resolution == "audio only":
+            return (0, 0)
+        return tuple(map(int, resolution.split("x")))
+
+    return sorted(
+        formats, key=lambda x: resolution_to_tuple(x["resolution"]), reverse=True
+    )
+
+
+def sort_by_tbr(formats):
+    """
+    Sort a list of video formats by their 'tbr' (total bitrate) in descending order.
+
+    Returns:
+        list: The input list sorted by the 'tbr' value in descending order.
+    """
+    return sorted(formats, key=lambda x: x["tbr"], reverse=True)
+
+
+def sort_by_fps(formats):
+    """
+    Sort a list of video formats by frames per second (fps) in descending order.
+
+    Returns:
+        list of dict: The list of video formats sorted by fps in descending order.
+                      Formats with None fps values are placed at the end.
+    """
+    return sorted(
+        formats,
+        key=lambda x: (
+            x["fps"] is None,
+            -x["fps"] if x["fps"] is not None else float("-inf"),
+        ),
+    )
+
+
+def sort_by_size(formats):
+    """
+    Sort a list of video formats by their file size in descending order.
+
+    Returns:
+        list of dict: The list of video formats sorted by file size in
+                      descending order. Formats with no file size information
+                      (None) are placed at the end of the list.
+    """
+    return sorted(
+        formats,
+        key=lambda x: (
+            x["filesize"] is None,
+            -x["filesize"] if x["filesize"] is not None else float("-inf"),
+        ),
+    )
+
+
+def verify_ffmpeg_zip():
+    ffmpeg_zip = os.path.join(PLUGIN_ROOT, "ffmpeg.zip")
+    return not os.path.exists(ffmpeg_zip)
+
+
+def verify_ffmpeg_binaries():
+    ffmpeg_path = os.path.join(PLUGIN_ROOT, "ffmpeg.exe")
+    ffprobe_path = os.path.join(PLUGIN_ROOT, "ffprobe.exe")
+
+    return not os.path.exists(ffmpeg_path) or not os.path.exists(ffprobe_path)
+
+
+def verify_ffmpeg():
+    return verify_ffmpeg_zip() and verify_ffmpeg_binaries()
+
+
+def extract_ffmpeg():
+    ffmpeg_zip = os.path.join(PLUGIN_ROOT, "ffmpeg.zip")
+
+    if os.path.exists(ffmpeg_zip):
+        try:
+            with zipfile.ZipFile(ffmpeg_zip, "r") as zip_ref:
+                zip_ref.extractall(os.path.dirname(__file__))
+            os.remove(ffmpeg_zip)
+        except Exception as _:
+            pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyflowlauncher[all]
+pyflowlauncher
 yt-dlp


### PR DESCRIPTION
## **What's in this PR?**
- Fix the issue with the _yt-dlp_ path #16 
- Introduce dedicated _ffmpeg.exe_ and _ffprobe.exe_ for the plugin. Users need to download the binaries on time after the plugin update.
- Add more preferred video & audio formats in the settings
- Major code refactoring and simplification