### PR TITLE
Fix : FFmpeg path checking issue

### DIFF
--- a/plugin/main.py
+++ b/plugin/main.py
@@ -33,7 +33,7 @@ from results import (
 )
 from ytdlp import CustomYoutubeDL
 
-PLUGIN_ROOT = os.path.dirname(__file__)
+PLUGIN_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXE_PATH = os.path.join(PLUGIN_ROOT, "yt-dlp.exe")
 CHECK_INTERVAL_DAYS = 5
 DEFAULT_DOWNLOAD_PATH = str(Path.home() / "Downloads")
@@ -74,7 +74,7 @@ def fetch_settings() -> Tuple[str, str, str, str]:
 def query(query: str) -> ResultResponse:
     d_path, sort, pvf, paf = fetch_settings()
 
-    if verify_ffmpeg():
+    if not verify_ffmpeg():
         return send_results([download_ffmpeg_result(PLUGIN_ROOT)])
 
     extract_ffmpeg()
@@ -123,7 +123,7 @@ def query(query: str) -> ResultResponse:
 
     results = []
 
-    if verify_ffmpeg_binaries():
+    if not verify_ffmpeg_binaries():
         results.extend([ffmpeg_not_found_result()])
 
     results.extend(

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -3,7 +3,7 @@ import os
 import zipfile
 import shutil
 
-PLUGIN_ROOT = os.path.dirname(__file__)
+PLUGIN_ROOT = os.path.dirname(os.path.abspath(__file__))
 URL_REGEX = (
     "((http|https)://)(www.)?"
     + "[a-zA-Z0-9@:%._\\+~#?&//=]"
@@ -93,7 +93,7 @@ def sort_by_size(formats):
 
 def verify_ffmpeg_zip():
     ffmpeg_zip = os.path.join(PLUGIN_ROOT, "ffmpeg.zip")
-    return not os.path.exists(ffmpeg_zip)
+    return os.path.exists(ffmpeg_zip)
 
 
 def verify_ffmpeg_binaries():
@@ -101,12 +101,12 @@ def verify_ffmpeg_binaries():
     ffprobe_path = os.path.join(PLUGIN_ROOT, "ffprobe.exe")
 
     if os.path.exists(ffmpeg_path) and os.path.exists(ffprobe_path):
-        return False
+        return True
 
     if shutil.which("ffmpeg") and shutil.which("ffprobe"):
-        return False
+        return True
 
-    return True
+    return False
 
 
 def get_binaries_paths():
@@ -117,7 +117,7 @@ def get_binaries_paths():
 
 
 def verify_ffmpeg():
-    return verify_ffmpeg_zip() and verify_ffmpeg_binaries()
+    return verify_ffmpeg_zip() or verify_ffmpeg_binaries()
 
 
 def extract_ffmpeg():

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -92,11 +92,25 @@ def sort_by_size(formats):
 
 
 def verify_ffmpeg_zip():
+    """
+    Checks if the ffmpeg.zip file exists in the plugin directory.
+
+    Returns:
+        bool: False if the ffmpeg.zip file does not exist, True otherwise.
+    """
     ffmpeg_zip = os.path.join(PLUGIN_ROOT, "ffmpeg.zip")
     return os.path.exists(ffmpeg_zip)
 
 
 def verify_ffmpeg_binaries():
+    """
+    Verifies the presence of FFmpeg and FFprobe binaries.
+    This function checks if the FFmpeg and FFprobe binaries are present in the
+    plugin's root directory. If they are not found there, it checks if they are
+    available in the system's PATH.
+    Returns:
+        bool: True if both FFmpeg and FFprobe binaries are found, False otherwise.
+    """
     ffmpeg_path = os.path.join(PLUGIN_ROOT, "ffmpeg.exe")
     ffprobe_path = os.path.join(PLUGIN_ROOT, "ffprobe.exe")
 
@@ -110,6 +124,13 @@ def verify_ffmpeg_binaries():
 
 
 def get_binaries_paths():
+    """
+    Determines the path to the ffmpeg binaries.
+
+    Returns:
+        str: The directory path of the current file if ffmpeg binaries are verified.
+             Otherwise, returns the path to the ffmpeg executable found in the system PATH.
+    """
     if verify_ffmpeg_binaries():
         return os.path.dirname(__file__)
     else:
@@ -117,10 +138,29 @@ def get_binaries_paths():
 
 
 def verify_ffmpeg():
+    """
+    Verify the presence and integrity of FFmpeg.
+
+    This function checks if the FFmpeg zip file and binaries are present and valid.
+    It returns True if both the zip file and binaries are verified successfully, otherwise False.
+
+    Returns:
+        bool: True if both FFmpeg zip file and binaries are verified, False otherwise.
+    """
     return verify_ffmpeg_zip() or verify_ffmpeg_binaries()
 
 
 def extract_ffmpeg():
+    """
+    Extracts the ffmpeg.zip file located in the plugin root directory.
+    This function checks if the ffmpeg.zip file exists in the plugin root directory.
+    If it exists, it extracts the contents of the zip file to the directory of the
+    current script and then removes the zip file.
+    Note:
+        If an exception occurs during the extraction process, it is silently ignored.
+    Raises:
+        None
+    """
     ffmpeg_zip = os.path.join(PLUGIN_ROOT, "ffmpeg.zip")
 
     if os.path.exists(ffmpeg_zip):
@@ -130,3 +170,4 @@ def extract_ffmpeg():
             os.remove(ffmpeg_zip)
         except Exception as _:
             pass
+


### PR DESCRIPTION
This pull request includes several changes to the `plugin` directory, focusing on improving path handling and enhancing function documentation. The most important changes involve modifying the way paths are determined and adding detailed docstrings to utility functions.

### Logic Corrections:
* [`plugin/main.py`](diffhunk://#diff-84b4ebda4050f6a6a29a7d99268a971d9861b7159b33db621932f37bf67c62efL77-R77): Fixed the logic in `query` function to correctly handle the absence of FFmpeg by changing `if verify_ffmpeg()` to `if not verify_ffmpeg()`.
* [`plugin/main.py`](diffhunk://#diff-84b4ebda4050f6a6a29a7d99268a971d9861b7159b33db621932f37bf67c62efL126-R126): Corrected the logic in `query` function to check for FFmpeg binaries correctly by changing `if verify_ffmpeg_binaries()` to `if not verify_ffmpeg_binaries()`.
