### PR TITLE
[FIX] Enhance yt-dlp pip package update check logic

### DIFF
--- a/plugin/main.py
+++ b/plugin/main.py
@@ -159,6 +159,9 @@ def query(query: str) -> ResultResponse:
     ydl = CustomYoutubeDL(params=ydl_opts)
     info = ydl.extract_info(query)
 
+    if info is None:
+        return send_results([error_result()])
+
     formats = [
         {
             "format_id": format.get("format_id"),
@@ -184,8 +187,6 @@ def query(query: str) -> ResultResponse:
         formats = sort_by_tbr(formats)
     elif sort == "FPS":
         formats = sort_by_fps(formats)
-
-    needs_update = check_ytdlp_version(CHECK_INTERVAL_DAYS)
 
     results = []
 
@@ -217,7 +218,6 @@ def query(query: str) -> ResultResponse:
                     pvf,
                     paf,
                     auto_open,
-                    needs_update,
                 )
             )
         except (ValueError, TypeError):
@@ -237,7 +237,6 @@ def query(query: str) -> ResultResponse:
                     pvf,
                     paf,
                     auto_open,
-                    needs_update,
                 )
             )
         except (ValueError, TypeError):
@@ -254,7 +253,6 @@ def query(query: str) -> ResultResponse:
                 pvf,
                 paf,
                 auto_open,
-                needs_update,
             )
             for format in formats
         ]
@@ -271,9 +269,8 @@ def download(
     pref_audio_path: str,
     is_audio: bool,
     auto_open_folder: bool = False,
-    needs_update: bool = False,
 ) -> None:
-    if needs_update:
+    if check_ytdlp_version(CHECK_INTERVAL_DAYS):
         update_ytdlp_library()
 
     exe_path = os.path.join(os.path.dirname(__file__), "yt-dlp.exe")

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -154,6 +154,7 @@ def query(query: str) -> ResultResponse:
     ydl_opts = {
         "quiet": True,
         "no_warnings": True,
+        "socket_timeout": 30,
     }
     ydl = CustomYoutubeDL(params=ydl_opts)
     info = ydl.extract_info(query)

--- a/plugin/results.py
+++ b/plugin/results.py
@@ -65,7 +65,6 @@ def best_video_result(
     pref_video_path,
     pref_audio_path,
     auto_open_folder=False,
-    needs_update=False,
 ) -> Result:
     result_title = "★ BEST VIDEO QUALITY"
     if format.get("resolution"):
@@ -84,7 +83,6 @@ def best_video_result(
                 pref_audio_path,
                 False,
                 auto_open_folder,
-                needs_update,
             ],
         },
     )
@@ -98,7 +96,6 @@ def best_audio_result(
     pref_video_path,
     pref_audio_path,
     auto_open_folder=False,
-    needs_update=False,
 ) -> Result:
     result_title = "★ BEST AUDIO ONLY"
     if format.get("tbr"):
@@ -117,7 +114,6 @@ def best_audio_result(
                 pref_audio_path,
                 True,
                 auto_open_folder,
-                needs_update,
             ],
         },
     )
@@ -132,7 +128,6 @@ def query_result(
     pref_video_path,
     pref_audio_path,
     auto_open_folder=False,
-    needs_update=False,
 ) -> Result:
     # Build subtitle with consistent spacing
     subtitle_parts = [f"Res: {format['resolution']}"]
@@ -163,7 +158,6 @@ def query_result(
                 pref_audio_path,
                 format["resolution"] == "audio only",
                 auto_open_folder,
-                needs_update,
             ],
         },
     )

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -105,8 +105,7 @@ class TestBestVideoResult:
     def test_json_rpc_action_parameters(self):
         fmt = self._make_format()
         r = best_video_result("http://example.com", "thumb.jpg", fmt,
-                              "/downloads", "mp4", "mp3", auto_open_folder=True,
-                              needs_update=True)
+                              "/downloads", "mp4", "mp3", auto_open_folder=True)
         params = r.JsonRPCAction["parameters"]
         assert params[0] == "http://example.com"
         assert params[1] == "137"
@@ -115,14 +114,6 @@ class TestBestVideoResult:
         assert params[4] == "mp3"
         assert params[5] is False  # is_audio
         assert params[6] is True   # auto_open_folder
-        assert params[7] is True   # needs_update
-
-    def test_needs_update_false_by_default(self):
-        fmt = self._make_format()
-        r = best_video_result("http://example.com", None, fmt,
-                              "/downloads", "mp4", "mp3")
-        params = r.JsonRPCAction["parameters"]
-        assert params[7] is False
 
     def test_thumbnail_fallback(self):
         fmt = self._make_format()
@@ -157,13 +148,6 @@ class TestBestAudioResult:
                               "/downloads", "mp4", "mp3")
         params = r.JsonRPCAction["parameters"]
         assert params[5] is True  # is_audio
-
-    def test_needs_update_propagation(self):
-        fmt = {"format_id": "140", "tbr": 128}
-        r = best_audio_result("http://example.com", None, fmt,
-                              "/downloads", "mp4", "mp3", needs_update=True)
-        params = r.JsonRPCAction["parameters"]
-        assert params[7] is True
 
 
 class TestQueryResult:
@@ -210,13 +194,6 @@ class TestQueryResult:
                          "/downloads", "mp4", "mp3")
         params = r.JsonRPCAction["parameters"]
         assert params[5] is False  # is_audio
-
-    def test_needs_update_in_params(self):
-        fmt = self._make_format()
-        r = query_result("http://example.com", None, "Test Video", fmt,
-                         "/downloads", "mp4", "mp3", needs_update=True)
-        params = r.JsonRPCAction["parameters"]
-        assert params[7] is True
 
     def test_title_pass_through(self):
         fmt = self._make_format()


### PR DESCRIPTION
This pull request refactors how the plugin checks for and handles updates to the `yt-dlp` library. The update logic has been centralized to occur only at the point of download, rather than being propagated through multiple function calls and parameters. As a result, the `needs_update` parameter has been removed from many functions and their associated tests, simplifying the codebase and reducing unnecessary complexity.

**Refactoring and simplification of update logic:**

* Centralized the `yt-dlp` update check to the `download` function, removing the `needs_update` parameter from `download`, `best_video_result`, `best_audio_result`, and `query_result`, as well as all related function calls and tests. The update is now triggered directly in `download` if needed, rather than being passed through multiple layers

**Error handling improvements:**

* Added a check for `None` when extracting info in the `query` function, returning an error result if extraction fails, improving robustness.

**Test cleanup:**

* Removed all tests related to the `needs_update` parameter, reflecting the new centralized update logic and simplifying the test suite.

**Other improvements:**

* Added a `socket_timeout` option to `ydl_opts` for better network reliability.